### PR TITLE
Separate configurable variables to config.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build
 node_modules
 .DS_Store
 
+config.js

--- a/app.js
+++ b/app.js
@@ -14,9 +14,10 @@ var irc = require('irc');
 var xss = require('xss');
 var fs = require('fs');
 var app = express();
+var config = require('./config/config.js');
 
 // all environments
-app.set('port', process.env.PORT || 80);
+app.set('port', process.env.PORT || config.server.port || 80);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 app.use(express.favicon());
@@ -65,18 +66,18 @@ io.sockets.on('connection', function (socket) {
 	
 });
 
-var client = new irc.Client('irc.freenode.net', 'SITCON_BOT', {
-    channels: ['#sitcon'],debug:true
+var client = new irc.Client(config.irc.server, config.irc.bot_nick, {
+    channels: [config.irc.channel],debug:true
 });
 
 client.addListener('error', function(message) {
     console.log('error: ', message);
 });
 
-client.join('#sitcon sitcon_bot_pwd');
+client.join(config.irc.channel + ' ' + config.irc.bot_pwd);
 
 client.addListener('message', function (from, to, message) {
-	console.log("SITCON IRC : " + from + ' => ' + to + ': ' + message);
+	console.log(config.irc.channel + " IRC : " + from + ' => ' + to + ': ' + message);
 	message = xss(message);
 	io.sockets.emit('irc_msg', {'from':from, 'to': to, 'msg':message});
 });

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -1,0 +1,18 @@
+(function(){
+    var config = function(){
+        var server_conf = function(){//{{{
+            this.port = 80
+        };//}}}
+        var irc_conf = function(){//{{{
+            this.server = 'chat.freenode.net',
+            this.channel = '#sitcon',
+            this.bot_nick = 'SITCON_BOT'
+            this.bot_pwd = 'sitcon_bot_pwd'
+        };//}}}
+
+        this.server = new server_conf();
+        this.irc = new irc_conf();
+    };
+
+    module.exports = new config();
+})();


### PR DESCRIPTION
There is some hard coding with irc channel name, bot nick name ...etc .
I separate those var into an isolated file, config.js, and there is a sample file provided.
To include the config.js, just use `var config = require('./config.js')`
The `config` object has the following structure current.

``` javascript
{
  server: {
    port: 80,
  },
  irc: {
    server: 'chat.irc.freenode.net',
    channel: '#sitcon',
    bot_nick: 'SITCON_BOT',
    bot_pwd: 'sitcon_bot_pwd',
}
```

Maybe this struct should be provided in documentation.

I think this seat system can also be used in other conference, so i try to make it configurable.
