### PR TITLE
Don't allow extended format query, since it could cause crash in some routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ app.set('view engine', 'ejs');
 app.use(express.favicon());
 app.use(express.logger('dev'));
 app.use(express.json());
-app.use(express.urlencoded());
+app.use(express.urlencoded({extended: false}));
 app.use(express.methodOverride());
 app.use(express.cookieParser(config.cookieSecret));
 app.use(express.cookieSession());


### PR DESCRIPTION
Attack used on last years Sitcon.
